### PR TITLE
Use xpc_type_t in struct xpc_object

### DIFF
--- a/src/libxpc/xpc_array.c
+++ b/src/libxpc/xpc_array.c
@@ -37,7 +37,7 @@ xpc_array_create(const xpc_object_t *objects, size_t count)
 	size_t i;
 	xpc_u val; bzero(&val, sizeof(val));
 
-	xo = _xpc_prim_create(_XPC_TYPE_ARRAY, val, 0);
+	xo = _xpc_prim_create(XPC_TYPE_ARRAY, val, 0);
 	
 	for (i = 0; i < count; i++)
 		xpc_array_append_value(xo, objects[i]);
@@ -54,7 +54,7 @@ xpc_array_set_value(xpc_object_t xarray, size_t index, xpc_object_t value)
 
 	xo = xarray;
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 	arr = &xo->xo_array;
 	i = 0;
 
@@ -84,7 +84,7 @@ xpc_array_append_value(xpc_object_t xarray, xpc_object_t value)
 	
 	xo = xarray;
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 	arr = &xo->xo_array;
 
 	TAILQ_INSERT_TAIL(arr, (struct xpc_object *)value, xo_link);
@@ -101,7 +101,7 @@ xpc_array_get_value(xpc_object_t xarray, size_t index)
 
 	xo = xarray;
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 	arr = &xo->xo_array;
 	i = 0;
 
@@ -123,7 +123,7 @@ xpc_array_get_count(xpc_object_t xarray)
 	xo = xarray;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	return (xo->xo_size);
 }
@@ -133,7 +133,7 @@ xpc_array_set_bool(xpc_object_t xarray, size_t index, bool value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xotmp = xpc_bool_create(value);
 	return (xpc_array_set_value(xarray, index, xotmp));
@@ -145,7 +145,7 @@ xpc_array_set_int64(xpc_object_t xarray, size_t index, int64_t value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_int64_create(value);
@@ -157,7 +157,7 @@ xpc_array_set_uint64(xpc_object_t xarray, size_t index, uint64_t value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_uint64_create(value);
@@ -169,7 +169,7 @@ xpc_array_set_double(xpc_object_t xarray, size_t index, double value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_double_create(value);
@@ -181,7 +181,7 @@ xpc_array_set_date(xpc_object_t xarray, size_t index, int64_t value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_date_create(value);
@@ -194,7 +194,7 @@ xpc_array_set_data(xpc_object_t xarray, size_t index, const void *data,
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_data_create(data, length);
@@ -206,7 +206,7 @@ xpc_array_set_string(xpc_object_t xarray, size_t index, const char *string)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_string_create(string);
@@ -218,7 +218,7 @@ xpc_array_set_uuid(xpc_object_t xarray, size_t index, const uuid_t value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_uuid_create(value);
@@ -230,7 +230,7 @@ xpc_array_set_fd(xpc_object_t xarray, size_t index, int value)
 {
 	struct xpc_object *xo = xarray, *xotmp;
 	xpc_assert_nonnull(xarray);
-	xpc_assert_type(xo, _XPC_TYPE_ARRAY);
+	xpc_assert_type(xo, XPC_TYPE_ARRAY);
 
 	xo = xarray;
 	xotmp = xpc_fd_create(value);
@@ -308,7 +308,7 @@ int
 xpc_array_dup_fd(xpc_object_t array, size_t index)
 {
 	xpc_object_t xotmp = xpc_array_get_value(array, index);
-	xpc_assert_type(((struct xpc_object *)xotmp), _XPC_TYPE_FD);
+	xpc_assert_type(((struct xpc_object *)xotmp), XPC_TYPE_FD);
 	return xpc_fd_dup(xotmp);
 }
 

--- a/src/libxpc/xpc_dictionary.c
+++ b/src/libxpc/xpc_dictionary.c
@@ -31,7 +31,7 @@
 #include "xpc_internal.h"
 #include <assert.h>
 
-#define NVLISTXPC_TYPE		"_XPC_TYPE"
+#define NVLIST_XPC_TYPE		"__XPC_TYPE"
 
 static void xpc2nv_primitive(nvlist_t *nv, const char *key, xpc_object_t value);
 
@@ -60,8 +60,8 @@ nv2xpc(const nvlist_t *nv)
 	xpc_assert(nvlist_type(nv) == NV_TYPE_NVLIST_DICTIONARY || nvlist_type(nv) == NV_TYPE_NVLIST_ARRAY, "nvlist_t %p is not dictionary or array", nv);
 
 	if (nvlist_type(nv) == NV_TYPE_NVLIST_DICTIONARY) {
-		if (nvlist_contains_key(nv, NVLISTXPC_TYPE)) {
-			const char *type = nvlist_get_string(nv, NVLISTXPC_TYPE);
+		if (nvlist_contains_key(nv, NVLIST_XPC_TYPE)) {
+			const char *type = nvlist_get_string(nv, NVLIST_XPC_TYPE);
 
 			if (strcmp(type, "connection") == 0) {
 				val.i = nvlist_get_int64(nv, "connection");
@@ -77,7 +77,7 @@ nv2xpc(const nvlist_t *nv)
 				xpc_assert(value_size == sizeof(double), "nvlist data of type date has incorrect size (expected %lu, got %zu)", sizeof(double), value_size);
 				return xpc_double_create(*value);
 			} else {
-				xpc_api_misuse("Unexpected NVLISTXPC_TYPE in dictionary: %s", type);
+				xpc_api_misuse("Unexpected NVLIST_XPC_TYPE in dictionary: %s", type);
 			}
 		}
 
@@ -165,13 +165,13 @@ xpc2nv_primitive(nvlist_t *nv, const char *key, xpc_object_t value)
 		nvlist_add_bool(nv, key, xpc_bool_get_value(xotmp));
 	} else if (xotmp->xo_xpc_type == XPC_TYPE_CONNECTION) {
 		inner_nv = nvlist_create_dictionary(0);
-		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "connection");
+		nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "connection");
 		nvlist_add_int64(inner_nv, "connection", xotmp->xo_port);
 		nvlist_add_nvlist(nv, key, inner_nv);
 		nvlist_destroy(inner_nv);
 	} else if (xotmp->xo_xpc_type == XPC_TYPE_ENDPOINT) {
 		inner_nv = nvlist_create_dictionary(0);
-		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "endpoint");
+		nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "endpoint");
 		nvlist_add_int64(inner_nv, "endpoint", xotmp->xo_port);
 		nvlist_add_nvlist(nv, key, inner_nv);
 		nvlist_destroy(inner_nv);
@@ -181,7 +181,7 @@ xpc2nv_primitive(nvlist_t *nv, const char *key, xpc_object_t value)
 		nvlist_add_uint64(nv, key,  xpc_uint64_get_value(xotmp));
 	} else if (xotmp->xo_xpc_type == XPC_TYPE_DATE) {
 		inner_nv = nvlist_create_dictionary(0);
-		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "date");
+		nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "date");
 		nvlist_add_int64(inner_nv, "date", xotmp->xo_u.i);
 		nvlist_add_nvlist(nv, key, inner_nv);
 		nvlist_destroy(inner_nv);
@@ -199,7 +199,7 @@ xpc2nv_primitive(nvlist_t *nv, const char *key, xpc_object_t value)
 		xpc_api_misuse("Cannot serialize object of type error");
 	} else if (xotmp->xo_xpc_type == XPC_TYPE_DOUBLE) {
 		inner_nv = nvlist_create_dictionary(0);
-		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "double");
+		nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "double");
 		nvlist_add_binary(inner_nv, "double", &xotmp->xo_u.d, sizeof(double));
 		nvlist_add_nvlist(nv, key, inner_nv);
 		nvlist_destroy(inner_nv);

--- a/src/libxpc/xpc_dictionary.c
+++ b/src/libxpc/xpc_dictionary.c
@@ -31,7 +31,7 @@
 #include "xpc_internal.h"
 #include <assert.h>
 
-#define NVLIST_XPC_TYPE		"__XPC_TYPE"
+#define NVLISTXPC_TYPE		"_XPC_TYPE"
 
 static void xpc2nv_primitive(nvlist_t *nv, const char *key, xpc_object_t value);
 
@@ -60,15 +60,15 @@ nv2xpc(const nvlist_t *nv)
 	xpc_assert(nvlist_type(nv) == NV_TYPE_NVLIST_DICTIONARY || nvlist_type(nv) == NV_TYPE_NVLIST_ARRAY, "nvlist_t %p is not dictionary or array", nv);
 
 	if (nvlist_type(nv) == NV_TYPE_NVLIST_DICTIONARY) {
-		if (nvlist_contains_key(nv, NVLIST_XPC_TYPE)) {
-			const char *type = nvlist_get_string(nv, NVLIST_XPC_TYPE);
+		if (nvlist_contains_key(nv, NVLISTXPC_TYPE)) {
+			const char *type = nvlist_get_string(nv, NVLISTXPC_TYPE);
 
 			if (strcmp(type, "connection") == 0) {
 				val.i = nvlist_get_int64(nv, "connection");
-				return _xpc_prim_create(_XPC_TYPE_CONNECTION, val, 0);
+				return _xpc_prim_create(XPC_TYPE_CONNECTION, val, 0);
 			} else if (strcmp(type, "endpoint") == 0) {
 				val.i = nvlist_get_int64(nv, "endpoint");
-				return _xpc_prim_create(_XPC_TYPE_ENDPOINT, val, 0);
+				return _xpc_prim_create(XPC_TYPE_ENDPOINT, val, 0);
 			} else if (strcmp(type, "date") == 0) {
 				return xpc_date_create(nvlist_get_int64(nv, "date"));
 			} else if (strcmp(type, "double") == 0) {
@@ -77,7 +77,7 @@ nv2xpc(const nvlist_t *nv)
 				xpc_assert(value_size == sizeof(double), "nvlist data of type date has incorrect size (expected %lu, got %zu)", sizeof(double), value_size);
 				return xpc_double_create(*value);
 			} else {
-				xpc_api_misuse("Unexpected NVLIST_XPC_TYPE in dictionary: %s", type);
+				xpc_api_misuse("Unexpected NVLISTXPC_TYPE in dictionary: %s", type);
 			}
 		}
 
@@ -114,7 +114,7 @@ nv2xpc(const nvlist_t *nv)
 
 		case NV_TYPE_DESCRIPTOR:
 			val.fd = nvlist_get_descriptor(nv, key);
-			xotmp = _xpc_prim_create(_XPC_TYPE_FD, val, 0);
+			xotmp = _xpc_prim_create(XPC_TYPE_FD, val, 0);
 			break;
 
 		case NV_TYPE_PTR:
@@ -126,7 +126,7 @@ nv2xpc(const nvlist_t *nv)
 		case NV_TYPE_UUID:
 			memcpy(&val.uuid, nvlist_get_uuid(nv, key),
 			    sizeof(uuid_t));
-			xotmp = _xpc_prim_create(_XPC_TYPE_UUID, val, 0);
+			xotmp = _xpc_prim_create(XPC_TYPE_UUID, val, 0);
 
 		case NV_TYPE_NVLIST_ARRAY:
 			nvtmp = nvlist_get_nvlist_array(nv, key);
@@ -157,85 +157,54 @@ xpc2nv_primitive(nvlist_t *nv, const char *key, xpc_object_t value)
 	struct xpc_object *xotmp = value;
 	nvlist_t *inner_nv;
 
-	switch (xotmp->xo_xpc_type) {
-	case _XPC_TYPE_DICTIONARY:
+	if (xotmp->xo_xpc_type == XPC_TYPE_DICTIONARY) {
 		nvlist_add_nvlist_dictionary(nv, key, xpc2nv(xotmp));
-		break;
-
-	case _XPC_TYPE_ARRAY:
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_ARRAY) {
 		nvlist_add_nvlist_array(nv, key, xpc2nv(xotmp));
-		break;
-
-	case _XPC_TYPE_BOOL:
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_BOOL) {
 		nvlist_add_bool(nv, key, xpc_bool_get_value(xotmp));
-		break;
-
-	case _XPC_TYPE_CONNECTION:
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_CONNECTION) {
 		inner_nv = nvlist_create_dictionary(0);
-		nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "connection");
+		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "connection");
 		nvlist_add_int64(inner_nv, "connection", xotmp->xo_port);
 		nvlist_add_nvlist(nv, key, inner_nv);
 		nvlist_destroy(inner_nv);
-		break;
-
-	case _XPC_TYPE_ENDPOINT:
-			inner_nv = nvlist_create_dictionary(0);
-			nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "endpoint");
-			nvlist_add_int64(inner_nv, "endpoint", xotmp->xo_port);
-			nvlist_add_nvlist(nv, key, inner_nv);
-			nvlist_destroy(inner_nv);
-		break;
-
-	case _XPC_TYPE_INT64:
-		nvlist_add_int64(nv, key, xpc_int64_get_value(xotmp));
-		break;
-
-	case _XPC_TYPE_UINT64:
-		nvlist_add_uint64(nv, key,  xpc_uint64_get_value(xotmp));
-		break;
-
-	case _XPC_TYPE_DATE:
-			inner_nv = nvlist_create_dictionary(0);
-			nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "date");
-			nvlist_add_int64(inner_nv, "date", xotmp->xo_u.i);
-			nvlist_add_nvlist(nv, key, inner_nv);
-			nvlist_destroy(inner_nv);
-		break;
-
-	case _XPC_TYPE_DATA:
-		nvlist_add_binary(nv, key,
-		    xpc_data_get_bytes_ptr(xotmp),
-		    xpc_data_get_length(xotmp));
-		break;
-
-	case _XPC_TYPE_STRING:
-		nvlist_add_string(nv, key,
-		    xpc_string_get_string_ptr(xotmp));
-		break;
-
-	case _XPC_TYPE_UUID:
-		nvlist_add_uuid(nv, key, (uuid_t*)xpc_uuid_get_bytes(xotmp));
-		break;
-
-	case _XPC_TYPE_FD:
-		nvlist_add_descriptor(nv, key, xotmp->xo_fd);
-		break;
-
-	case _XPC_TYPE_SHMEM:
-		xpc_api_misuse("Cannot serialize object of type shared memory");
-		break;
-
-	case _XPC_TYPE_ERROR:
-		xpc_api_misuse("Cannot serialize object of type error");
-		break;
-
-	case _XPC_TYPE_DOUBLE:
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_ENDPOINT) {
 		inner_nv = nvlist_create_dictionary(0);
-		nvlist_add_string(inner_nv, NVLIST_XPC_TYPE, "double");
+		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "endpoint");
+		nvlist_add_int64(inner_nv, "endpoint", xotmp->xo_port);
+		nvlist_add_nvlist(nv, key, inner_nv);
+		nvlist_destroy(inner_nv);
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_INT64) {
+		nvlist_add_int64(nv, key, xpc_int64_get_value(xotmp));
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_UINT64) {
+		nvlist_add_uint64(nv, key,  xpc_uint64_get_value(xotmp));
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_DATE) {
+		inner_nv = nvlist_create_dictionary(0);
+		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "date");
+		nvlist_add_int64(inner_nv, "date", xotmp->xo_u.i);
+		nvlist_add_nvlist(nv, key, inner_nv);
+		nvlist_destroy(inner_nv);
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_DATA) {
+		nvlist_add_binary(nv, key, xpc_data_get_bytes_ptr(xotmp), xpc_data_get_length(xotmp));
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_STRING) {
+		nvlist_add_string(nv, key, xpc_string_get_string_ptr(xotmp));
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_UUID) {
+		nvlist_add_uuid(nv, key, (uuid_t*)xpc_uuid_get_bytes(xotmp));
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_FD) {
+		nvlist_add_descriptor(nv, key, xotmp->xo_fd);
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_SHMEM) {
+		xpc_api_misuse("Cannot serialize object of type shared memory");
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_ERROR) {
+		xpc_api_misuse("Cannot serialize object of type error");
+	} else if (xotmp->xo_xpc_type == XPC_TYPE_DOUBLE) {
+		inner_nv = nvlist_create_dictionary(0);
+		nvlist_add_string(inner_nv, NVLISTXPC_TYPE, "double");
 		nvlist_add_binary(inner_nv, "double", &xotmp->xo_u.d, sizeof(double));
 		nvlist_add_nvlist(nv, key, inner_nv);
 		nvlist_destroy(inner_nv);
-		break;
+	} else {
+		xpc_api_misuse("Unknown XPC type for object");
 	}
 }
 
@@ -245,7 +214,7 @@ xpc2nv(struct xpc_object *xo)
 	nvlist_t *nv;
 	struct xpc_object *xotmp;
 
-	if (xo->xo_xpc_type == _XPC_TYPE_DICTIONARY) {
+	if (xo->xo_xpc_type == XPC_TYPE_DICTIONARY) {
 		nv = nvlist_create_dictionary(0);
 		printf("nv = %p\n", nv);
 		xpc_dictionary_apply(xo, ^(const char *k, xpc_object_t v) {
@@ -256,7 +225,7 @@ xpc2nv(struct xpc_object *xo)
 		return nv;
 	}
 
-	if (xo->xo_xpc_type == _XPC_TYPE_ARRAY) {
+	if (xo->xo_xpc_type == XPC_TYPE_ARRAY) {
 		char *key = NULL;
 		nv = nvlist_create_array(0);
 		xpc_array_apply(xo, ^(size_t index, xpc_object_t v) {
@@ -281,7 +250,7 @@ xpc_dictionary_create(const char * const *keys, const xpc_object_t *values,
 	size_t i;
 	xpc_u val = {0};
 
-	xo = _xpc_prim_create(_XPC_TYPE_DICTIONARY, val, count);
+	xo = _xpc_prim_create(XPC_TYPE_DICTIONARY, val, count);
 	
 	for (i = 0; i < count; i++)
 		xpc_dictionary_set_value(xo, keys[i], values[i]);
@@ -325,13 +294,13 @@ xpc_dictionary_set_mach_recv(xpc_object_t xdict, const char *key, mach_port_t po
 {
 	struct xpc_object *xo = xdict;
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	struct xpc_object *xotmp;
 	xpc_u val;
 
 	val.port = port;
-	xotmp = _xpc_prim_create(_XPC_TYPE_ENDPOINT, val, 0);
+	xotmp = _xpc_prim_create(XPC_TYPE_ENDPOINT, val, 0);
 
 	xpc_dictionary_set_value(xdict, key, xotmp);
 }
@@ -343,7 +312,7 @@ xpc_dictionary_set_mach_send(xpc_object_t xdict, const char *key, mach_port_t po
 	xpc_u val;
 
 	val.port = port;
-	xotmp = _xpc_prim_create(_XPC_TYPE_ENDPOINT, val, 0);
+	xotmp = _xpc_prim_create(XPC_TYPE_ENDPOINT, val, 0);
 
 	xpc_dictionary_set_value(xdict, key, xotmp);
 }
@@ -354,13 +323,13 @@ xpc_dictionary_copy_mach_send(xpc_object_t xdict, const char *key)
 	struct xpc_object *xo = xdict;
 
 	xpc_assert_nonnull(xdict);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	xpc_object_t value = xpc_dictionary_get_value(xdict, key);
 	if (value == NULL) return MACH_PORT_NULL;
 
 	struct xpc_object *xovalue = value;
-	xpc_assert_type(xovalue, _XPC_TYPE_ENDPOINT);
+	xpc_assert_type(xovalue, XPC_TYPE_ENDPOINT);
 
 	return xovalue->xo_port;
 }
@@ -373,7 +342,7 @@ xpc_dictionary_set_value(xpc_object_t xdict, const char *key, xpc_object_t value
 	struct xpc_dict_pair *pair;
 
 	xpc_assert_nonnull(xdict);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	xo = xdict;
 	head = &xo->xo_dict;
@@ -403,7 +372,7 @@ xpc_dictionary_get_value(xpc_object_t xdict, const char *key)
 	struct xpc_dict_pair *pair;
 
 	xo = xdict;
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 	head = &xo->xo_dict;
 
 	TAILQ_FOREACH(pair, head, xo_link) {
@@ -422,7 +391,7 @@ xpc_dictionary_get_count(xpc_object_t xdict)
 	struct xpc_object *xo;
 
 	xo = xdict;
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 	return (xo->xo_size);
 }
 
@@ -432,7 +401,7 @@ xpc_dictionary_set_bool(xpc_object_t xdict, const char *key, bool value)
 	struct xpc_object *xo = xdict, *xotmp;
 
 	xpc_assert_nonnull(xdict);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	xo = xdict;
 	xotmp = xpc_bool_create(value);
@@ -445,7 +414,7 @@ xpc_dictionary_set_int64(xpc_object_t xdict, const char *key, int64_t value)
 	struct xpc_object *xo = xdict, *xotmp;
 
 	xpc_assert_nonnull(xdict);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	xo = xdict;
 	xotmp = xpc_int64_create(value);
@@ -458,7 +427,7 @@ xpc_dictionary_set_uint64(xpc_object_t xdict, const char *key, uint64_t value)
 	struct xpc_object *xo = xdict, *xotmp;
 
 	xpc_assert_nonnull(xdict);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	xo = xdict;
 	xotmp = xpc_uint64_create(value);
@@ -486,7 +455,7 @@ xpc_dictionary_get_bool(xpc_object_t xdict, const char *key)
 	if (value == NULL) return FALSE;
 
 	struct xpc_object *xo = value;
-	if (xo->xo_xpc_type != _XPC_TYPE_BOOL) return FALSE;
+	if (xo->xo_xpc_type != XPC_TYPE_BOOL) return FALSE;
 
 	return (xpc_bool_get_value(value));
 }
@@ -498,7 +467,7 @@ xpc_dictionary_get_int64(xpc_object_t xdict, const char *key)
 	if (value == NULL) return 0;
 
 	struct xpc_object *xo = value;
-	if (xo->xo_xpc_type != _XPC_TYPE_INT64) return 0;
+	if (xo->xo_xpc_type != XPC_TYPE_INT64) return 0;
 
 	return (xpc_int64_get_value(value));
 }
@@ -510,7 +479,7 @@ xpc_dictionary_get_uint64(xpc_object_t xdict, const char *key)
 	if (value == NULL) return 0;
 
 	struct xpc_object *xo = value;
-	if (xo->xo_xpc_type != _XPC_TYPE_UINT64) return 0;
+	if (xo->xo_xpc_type != XPC_TYPE_UINT64) return 0;
 
 	return (xpc_uint64_get_value(value));
 }
@@ -522,7 +491,7 @@ xpc_dictionary_get_string(xpc_object_t xdict, const char *key)
 	if (value == NULL) return 0;
 
 	struct xpc_object *xo = value;
-	if (xo->xo_xpc_type != _XPC_TYPE_STRING) return NULL;
+	if (xo->xo_xpc_type != XPC_TYPE_STRING) return NULL;
 
 	return (xpc_string_get_string_ptr(value));
 }
@@ -534,7 +503,7 @@ xpc_dictionary_get_data(xpc_object_t xdict, const char *key, size_t *length)
 	if (xdata == NULL) return NULL;
 
 	struct xpc_object *xo = xdata;
-	if (xo->xo_xpc_type != _XPC_TYPE_DATA) return NULL;
+	if (xo->xo_xpc_type != XPC_TYPE_DATA) return NULL;
 
 	if (length != NULL) *length = xpc_data_get_length(xdata);
 	return xpc_data_get_bytes_ptr(xdata);
@@ -548,7 +517,7 @@ xpc_dictionary_apply(xpc_object_t xdict, xpc_dictionary_applier_t applier)
 	struct xpc_dict_pair *pair;
 
 	xpc_assert_nonnull(xdict);
-	xpc_assert_type(xo, _XPC_TYPE_DICTIONARY);
+	xpc_assert_type(xo, XPC_TYPE_DICTIONARY);
 
 	head = &xo->xo_dict;
 

--- a/src/libxpc/xpc_error.c
+++ b/src/libxpc/xpc_error.c
@@ -47,7 +47,7 @@ struct _xpc_dictionary_s {
 const struct _xpc_dictionary_s _xpc_error_connection_interrupted;
 
 static const struct xpc_object _xpc_error_connection_interrupted_val = {
-	.xo_xpc_type = _XPC_TYPE_STRING,
+	.xo_xpc_type = XPC_TYPE_STRING,
 	.xo_size = 22,		/* strlen("Connection interrupted") */
 	.xo_refcnt = 1,
 	.xo_u = {
@@ -66,7 +66,7 @@ static const struct xpc_dict_pair _xpc_error_connection_interrupted_pair = {
 
 const struct _xpc_dictionary_s _xpc_error_connection_interrupted = {
 	.inner = {
-		.xo_xpc_type = _XPC_TYPE_DICTIONARY,
+		.xo_xpc_type = XPC_TYPE_DICTIONARY,
 		.xo_size = 1,
 		.xo_refcnt = 1,
 		.xo_u = {
@@ -83,7 +83,7 @@ const struct _xpc_dictionary_s _xpc_error_connection_interrupted = {
 const struct _xpc_dictionary_s _xpc_error_connection_invalid;
 
 static const struct xpc_object _xpc_error_connection_invalid_val = {
-	.xo_xpc_type = _XPC_TYPE_STRING,
+	.xo_xpc_type = XPC_TYPE_STRING,
 	.xo_size = 18,		/* strlen("Connection invalid") */
 	.xo_refcnt = 1,
 	.xo_u = {
@@ -102,7 +102,7 @@ static const struct xpc_dict_pair _xpc_error_connection_invalid_pair = {
 
 const struct _xpc_dictionary_s _xpc_error_connection_invalid = {
 	.inner = {
-		.xo_xpc_type = _XPC_TYPE_DICTIONARY,
+		.xo_xpc_type = XPC_TYPE_DICTIONARY,
 		.xo_size = 1,
 		.xo_refcnt = 1,
 		.xo_u = {
@@ -119,7 +119,7 @@ const struct _xpc_dictionary_s _xpc_error_connection_invalid = {
 const struct _xpc_dictionary_s _xpc_error_termination_imminent;
 
 static const struct xpc_object _xpc_error_termination_imminent_val = {
-	.xo_xpc_type = _XPC_TYPE_STRING,
+	.xo_xpc_type = XPC_TYPE_STRING,
 	.xo_size = 20,		/* strlen("Termination imminent") */
 	.xo_refcnt = 1,
 	.xo_u = {
@@ -138,7 +138,7 @@ static const struct xpc_dict_pair _xpc_error_termination_imminent_pair = {
 
 const struct _xpc_dictionary_s _xpc_error_termination_imminent = {
 	.inner = {
-		.xo_xpc_type = _XPC_TYPE_DICTIONARY,
+		.xo_xpc_type = XPC_TYPE_DICTIONARY,
 		.xo_size = 1,
 		.xo_refcnt = 1,
 		.xo_u = {

--- a/src/libxpc/xpc_internal.h
+++ b/src/libxpc/xpc_internal.h
@@ -43,27 +43,11 @@
     	fprintf(stderr, "\n");			\
     } while(0);
 
-#define _XPC_TYPE_INVALID		0
-#define _XPC_TYPE_DICTIONARY		1
-#define _XPC_TYPE_ARRAY			2
-#define _XPC_TYPE_BOOL			3
-#define _XPC_TYPE_CONNECTION		4
-#define _XPC_TYPE_ENDPOINT		5
-#define	_XPC_TYPE_NULL			6
-#define _XPC_TYPE_INT64			8
-#define _XPC_TYPE_UINT64		9
-#define _XPC_TYPE_DATE			10
-#define _XPC_TYPE_DATA			11
-#define _XPC_TYPE_STRING		12
-#define _XPC_TYPE_UUID			13
-#define _XPC_TYPE_FD			14
-#define _XPC_TYPE_SHMEM			15
-#define _XPC_TYPE_ERROR			16
-#define _XPC_TYPE_DOUBLE		17
-#define _XPC_TYPE_MAX			_XPC_TYPE_DOUBLE
-
 #define	XPC_SEQID	"XPC sequence number"
 #define	XPC_RPORT	"XPC remote port"
+
+#define _XPC_TYPE_INVALID (&_xpc_type_int64)
+__XNU_PRIVATE_EXTERN extern XPC_TYPE(_xpc_type_invalid);
 
 struct xpc_object;
 struct xpc_dict_pair;
@@ -90,7 +74,7 @@ typedef union {
 #define _XPC_STATIC_OBJECT_FLAG 0x2
 
 struct xpc_object {
-	uint8_t			xo_xpc_type;
+	xpc_type_t		xo_xpc_type;
 	uint16_t		xo_flags;
 	volatile uint32_t	xo_refcnt;
 	size_t			xo_size;
@@ -155,9 +139,9 @@ struct xpc_service {
 #define xo_array xo_u.array
 #define xo_dict xo_u.dict
 
-__private_extern__ struct xpc_object *_xpc_prim_create(int type, xpc_u value,
+__private_extern__ struct xpc_object *_xpc_prim_create(xpc_type_t type, xpc_u value,
     size_t size);
-__private_extern__ struct xpc_object *_xpc_prim_create_flags(int type,
+__private_extern__ struct xpc_object *_xpc_prim_create_flags(xpc_type_t type,
     xpc_u value, size_t size, uint16_t flags);
 __private_extern__ const char *_xpc_get_type_name(xpc_object_t obj);
 __private_extern__ struct xpc_object *nv2xpc(const nvlist_t *nv);

--- a/src/libxpc/xpc_type.c
+++ b/src/libxpc/xpc_type.c
@@ -37,7 +37,7 @@ struct _xpc_type_s {
 };
 
 typedef const struct _xpc_type_s xt;
-xt _xpc_type_invalid = { "<invalid> "};
+xt _xpc_type_invalid = { "<invalid>" };
 xt _xpc_type_array = { "array" };
 xt _xpc_type_bool = { "bool" };
 xt _xpc_type_connection = { "connection" };

--- a/src/libxpc/xpc_type.c
+++ b/src/libxpc/xpc_type.c
@@ -33,25 +33,27 @@
 #include "xpc_internal.h"
 
 struct _xpc_type_s {
+	const char *description;
 };
 
 typedef const struct _xpc_type_s xt;
-xt _xpc_type_array;
-xt _xpc_type_bool;
-xt _xpc_type_connection;
-xt _xpc_type_data;
-xt _xpc_type_date;
-xt _xpc_type_dictionary;
-xt _xpc_type_endpoint;
-xt _xpc_type_null;
-xt _xpc_type_error;
-xt _xpc_type_fd;
-xt _xpc_type_int64;
-xt _xpc_type_uint64;
-xt _xpc_type_shmem;
-xt _xpc_type_string;
-xt _xpc_type_uuid;
-xt _xpc_type_double;
+xt _xpc_type_invalid = { "<invalid> "};
+xt _xpc_type_array = { "array" };
+xt _xpc_type_bool = { "bool" };
+xt _xpc_type_connection = { "connection" };
+xt _xpc_type_data = { "data" };
+xt _xpc_type_date = { "date" };
+xt _xpc_type_dictionary = { "dictionary" };
+xt _xpc_type_endpoint = { "endpoint" };
+xt _xpc_type_null = { "null" };
+xt _xpc_type_error = { "error" };
+xt _xpc_type_fd = { "file descriptor" };
+xt _xpc_type_int64 = { "int64" };
+xt _xpc_type_uint64 = { "uint64" };
+xt _xpc_type_shmem = { "shared memory" };
+xt _xpc_type_string = { "string" };
+xt _xpc_type_uuid = { "UUID" };
+xt _xpc_type_double = { "double" };
 
 
 struct _xpc_bool_s {
@@ -107,14 +109,14 @@ static const char *xpc_typestr[] = {
 };
 
 __private_extern__ struct xpc_object *
-_xpc_prim_create(int type, xpc_u value, size_t size)
+_xpc_prim_create(xpc_type_t type, xpc_u value, size_t size)
 {
 
 	return (_xpc_prim_create_flags(type, value, size, 0));
 }
 
 __private_extern__ struct xpc_object *
-_xpc_prim_create_flags(int type, xpc_u value, size_t size, uint16_t flags)
+_xpc_prim_create_flags(xpc_type_t type, xpc_u value, size_t size, uint16_t flags)
 {
 	struct xpc_object *xo;
 
@@ -128,10 +130,10 @@ _xpc_prim_create_flags(int type, xpc_u value, size_t size, uint16_t flags)
 	xo->xo_refcnt = 1;
 	xo->xo_audit_token = NULL;
 
-	if (type == _XPC_TYPE_DICTIONARY)
+	if (type == XPC_TYPE_DICTIONARY)
 		TAILQ_INIT(&xo->xo_dict);
 
-	if (type == _XPC_TYPE_ARRAY)
+	if (type == XPC_TYPE_ARRAY)
 		TAILQ_INIT(&xo->xo_array);
 
 	return (xo);
@@ -141,7 +143,7 @@ xpc_object_t
 xpc_null_create(void)
 {
 	xpc_u val = {0};
-	return _xpc_prim_create(_XPC_TYPE_NULL, val, 0);
+	return _xpc_prim_create(XPC_TYPE_NULL, val, 0);
 }
 
 xpc_object_t
@@ -150,7 +152,7 @@ xpc_bool_create(bool value)
 	xpc_u val;
 
 	val.b = value;
-	return _xpc_prim_create(_XPC_TYPE_BOOL, val, 1);
+	return _xpc_prim_create(XPC_TYPE_BOOL, val, 1);
 }
 
 bool
@@ -159,7 +161,7 @@ xpc_bool_get_value(xpc_object_t xbool)
 	struct xpc_object *xo = xbool;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_BOOL);
+	xpc_assert_type(xo, XPC_TYPE_BOOL);
 
 	return (xo->xo_bool);
 }
@@ -170,7 +172,7 @@ xpc_int64_create(int64_t value)
 	xpc_u val;
 
 	val.i = value;
-	return _xpc_prim_create(_XPC_TYPE_INT64, val, 1);
+	return _xpc_prim_create(XPC_TYPE_INT64, val, 1);
 }
 
 int64_t
@@ -179,7 +181,7 @@ xpc_int64_get_value(xpc_object_t xint)
 	struct xpc_object *xo = xint;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_INT64);
+	xpc_assert_type(xo, XPC_TYPE_INT64);
 
 	return (xo->xo_int);
 }
@@ -190,7 +192,7 @@ xpc_uint64_create(uint64_t value)
 	xpc_u val;
 
 	val.ui = value;
-	return _xpc_prim_create(_XPC_TYPE_UINT64, val, 1);
+	return _xpc_prim_create(XPC_TYPE_UINT64, val, 1);
 }
 
 uint64_t
@@ -199,7 +201,7 @@ xpc_uint64_get_value(xpc_object_t xuint)
 	struct xpc_object *xo = xuint;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_UINT64);
+	xpc_assert_type(xo, XPC_TYPE_UINT64);
 
 	return (xo->xo_uint);
 }
@@ -210,7 +212,7 @@ xpc_double_create(double value)
 	xpc_u val;
 
 	val.d = value;
-	return _xpc_prim_create(_XPC_TYPE_DOUBLE, val, 1);
+	return _xpc_prim_create(XPC_TYPE_DOUBLE, val, 1);
 }
 
 double
@@ -219,7 +221,7 @@ xpc_double_get_value(xpc_object_t xdouble)
 	struct xpc_object *xo = xdouble;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_DOUBLE);
+	xpc_assert_type(xo, XPC_TYPE_DOUBLE);
 
 	return (xo->xo_d);
 }
@@ -230,7 +232,7 @@ xpc_date_create(int64_t interval)
 	xpc_u val;
 
 	val.i = interval;
-	return _xpc_prim_create(_XPC_TYPE_DATE, val, 1);
+	return _xpc_prim_create(XPC_TYPE_DATE, val, 1);
 }
 
 xpc_object_t
@@ -245,7 +247,7 @@ xpc_date_get_value(xpc_object_t xdate)
 	struct xpc_object *xo = xdate;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_DATE);
+	xpc_assert_type(xo, XPC_TYPE_DATE);
 
 	return (xo->xo_int);
 }
@@ -257,7 +259,7 @@ xpc_data_create(const void *bytes, size_t length)
 
 	val.ptr = (uintptr_t)malloc(length);
 	memcpy((void *)val.ptr, bytes, length);
-	return _xpc_prim_create(_XPC_TYPE_DATA, val, length);
+	return _xpc_prim_create(XPC_TYPE_DATA, val, length);
 }
 
 xpc_object_t
@@ -272,7 +274,7 @@ xpc_data_get_length(xpc_object_t xdata)
 	struct xpc_object *xo = xdata;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_DATA);
+	xpc_assert_type(xo, XPC_TYPE_DATA);
 
 	return (xo->xo_size);
 }
@@ -283,7 +285,7 @@ xpc_data_get_bytes_ptr(xpc_object_t xdata)
 	struct xpc_object *xo = xdata;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_DATA);
+	xpc_assert_type(xo, XPC_TYPE_DATA);
 
 	return (void *)(xo->xo_ptr);
 }
@@ -294,7 +296,7 @@ xpc_data_get_bytes(xpc_object_t xdata, void *buffer, size_t off, size_t length)
 	struct xpc_object *xo = xdata;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_DATA);
+	xpc_assert_type(xo, XPC_TYPE_DATA);
 
 	size_t length_to_copy = length;
 	if (length_to_copy > xo->xo_size) length_to_copy = xo->xo_size;
@@ -311,7 +313,7 @@ xpc_fd_create(int fd)
 {
 	xpc_u val;
 	fileport_makeport(fd, &val.port);
-	return _xpc_prim_create(_XPC_TYPE_FD, val, sizeof(val.port));
+	return _xpc_prim_create(XPC_TYPE_FD, val, sizeof(val.port));
 }
 
 int
@@ -320,7 +322,7 @@ xpc_fd_dup(xpc_object_t xfd)
 	struct xpc_object *xo = xfd;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_FD);
+	xpc_assert_type(xo, XPC_TYPE_FD);
 
 	return fileport_makefd(xo->xo_u.port);
 }
@@ -331,7 +333,7 @@ xpc_string_create(const char *string)
 	xpc_u val;
 
 	val.str = strdup(string);
-	return _xpc_prim_create(_XPC_TYPE_STRING, val, strlen(string));
+	return _xpc_prim_create(XPC_TYPE_STRING, val, strlen(string));
 }
 
 xpc_object_t
@@ -343,7 +345,7 @@ xpc_string_create_with_format(const char *fmt, ...)
 	va_start(ap, fmt);
 	vasprintf((char **)&val.str, fmt, ap);
 	va_end(ap);
-	return _xpc_prim_create(_XPC_TYPE_STRING, val, strlen(val.str));
+	return _xpc_prim_create(XPC_TYPE_STRING, val, strlen(val.str));
 }
 
 xpc_object_t
@@ -352,7 +354,7 @@ xpc_string_create_with_format_and_arguments(const char *fmt, va_list ap)
 	xpc_u val;
 
 	vasprintf((char **)&val.str, fmt, ap);
-	return _xpc_prim_create(_XPC_TYPE_STRING, val, strlen(val.str));
+	return _xpc_prim_create(XPC_TYPE_STRING, val, strlen(val.str));
 }
 
 size_t
@@ -361,7 +363,7 @@ xpc_string_get_length(xpc_object_t xstring)
 	struct xpc_object *xo = xstring;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_STRING);
+	xpc_assert_type(xo, XPC_TYPE_STRING);
 
 	return (xo->xo_size);
 }
@@ -372,7 +374,7 @@ xpc_string_get_string_ptr(xpc_object_t xstring)
 	struct xpc_object *xo = xstring;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_STRING);
+	xpc_assert_type(xo, XPC_TYPE_STRING);
 
 	return (xo->xo_str);
 }
@@ -383,7 +385,7 @@ xpc_uuid_create(const uuid_t uuid)
 	xpc_u val;
 
 	memcpy(val.uuid, uuid, sizeof(uuid_t));
-	return _xpc_prim_create(_XPC_TYPE_UUID, val, 1);
+	return _xpc_prim_create(XPC_TYPE_UUID, val, 1);
 }
 
 const uint8_t *
@@ -392,7 +394,7 @@ xpc_uuid_get_bytes(xpc_object_t xuuid)
 	struct xpc_object *xo = xuuid;
 
 	xpc_assert_nonnull(xo);
-	xpc_assert_type(xo, _XPC_TYPE_UUID);
+	xpc_assert_type(xo, XPC_TYPE_UUID);
 
 	return ((uint8_t*)&xo->xo_uuid);
 }
@@ -403,7 +405,7 @@ xpc_get_type(xpc_object_t obj)
 	struct xpc_object *xo;
 
 	xo = obj;
-	return (xpc_typemap[xo->xo_xpc_type]);
+	return xo->xo_xpc_type;
 }
 
 bool
@@ -419,58 +421,52 @@ xpc_equal(xpc_object_t x1, xpc_object_t x2)
 
 	if (xo1->xo_xpc_type != xo2->xo_xpc_type) return false;
 
-	switch (xo1->xo_xpc_type) {
-		case _XPC_TYPE_BOOL:
-			return xo1->xo_u.b == xo2->xo_u.b;
-		case _XPC_TYPE_INT64:
-		case _XPC_TYPE_DATE:
-			return xo1->xo_u.i == xo2->xo_u.i;
-		case _XPC_TYPE_UINT64:
-			return xo1->xo_u.ui == xo2->xo_u.ui;
-		case _XPC_TYPE_ENDPOINT:
-			return xo1->xo_u.port == xo2->xo_u.port;
-		case _XPC_TYPE_STRING:
-			return strcmp(xo1->xo_u.str, xo1->xo_u.str) == 0;
-		case _XPC_TYPE_DATA:
-			if (xo1->xo_size != xo2->xo_size) return false;
-			return memcmp((void *)xo1->xo_u.ptr, (void *)xo2->xo_u.ptr, xo1->xo_size) == 0;
-		case _XPC_TYPE_DICTIONARY:
-		{
-			struct xpc_dict_pair *pair;
-			size_t count1 = 0, count2 = 0;
-			TAILQ_FOREACH(pair, &xo1->xo_u.dict, xo_link) {
-				count1++;
-			}
-			TAILQ_FOREACH(pair, &xo2->xo_u.dict, xo_link) {
-				count2++;
-			}
-
-			if (count1 != count2) return false;
-
-			TAILQ_FOREACH(pair, &xo1->xo_u.dict, xo_link) {
-				struct xpc_object *value1 = pair->value;
-				struct xpc_object *value2 = xpc_dictionary_get_value(xo2, pair->key);
-				if (value2 == NULL) return false;
-				if (!xpc_equal(value1, value2)) return false;
-			}
-
-			TAILQ_FOREACH(pair, &xo2->xo_u.dict, xo_link) {
-				if (xpc_dictionary_get_value(xo1, pair->key) == NULL) return false;
-			}
-
-			return true;
+	if (xo1->xo_xpc_type == XPC_TYPE_BOOL) {
+		return xo1->xo_u.b == xo2->xo_u.b;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_INT64 || xo1->xo_xpc_type == XPC_TYPE_DATE) {
+		return xo1->xo_u.i == xo2->xo_u.i;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_UINT64) {
+		return xo1->xo_u.ui == xo2->xo_u.ui;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_ENDPOINT) {
+		return xo1->xo_u.port == xo2->xo_u.port;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_STRING) {
+		return strcmp(xo1->xo_u.str, xo1->xo_u.str) == 0;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_DATA) {
+		if (xo1->xo_size != xo2->xo_size) return false;
+		return memcmp((void *)xo1->xo_u.ptr, (void *)xo2->xo_u.ptr, xo1->xo_size) == 0;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_DICTIONARY) {
+		struct xpc_dict_pair *pair;
+		size_t count1 = 0, count2 = 0;
+		TAILQ_FOREACH(pair, &xo1->xo_u.dict, xo_link) {
+			count1++;
 		}
-		case _XPC_TYPE_ARRAY:
-		{
-			if (xpc_array_get_count(xo1) != xpc_array_get_count(xo2)) return false;
-
-			return xpc_array_apply(xo1, ^bool(size_t index, xpc_object_t value) {
-				return xpc_equal(value, xpc_array_get_value(xo2, index));
-			});
+		TAILQ_FOREACH(pair, &xo2->xo_u.dict, xo_link) {
+			count2++;
 		}
+
+		if (count1 != count2) return false;
+
+		TAILQ_FOREACH(pair, &xo1->xo_u.dict, xo_link) {
+			struct xpc_object *value1 = pair->value;
+			struct xpc_object *value2 = xpc_dictionary_get_value(xo2, pair->key);
+			if (value2 == NULL) return false;
+			if (!xpc_equal(value1, value2)) return false;
+		}
+
+		TAILQ_FOREACH(pair, &xo2->xo_u.dict, xo_link) {
+			if (xpc_dictionary_get_value(xo1, pair->key) == NULL) return false;
+		}
+
+		return true;
+	} else if (xo1->xo_xpc_type == XPC_TYPE_ARRAY) {
+		if (xpc_array_get_count(xo1) != xpc_array_get_count(xo2)) return false;
+
+		return xpc_array_apply(xo1, ^bool(size_t index, xpc_object_t value) {
+			return xpc_equal(value, xpc_array_get_value(xo2, index));
+		});
+	} else {
+		xpc_api_misuse("xpc_equal() is not implemented for this object type");
 	}
-
-    xpc_api_misuse("xpc_equal() is not implemented for this object type");
 }
 
 static size_t
@@ -491,40 +487,29 @@ xpc_hash(xpc_object_t obj)
 	__block size_t hash = 0;
 
 	xo = obj;
-	switch (xo->xo_xpc_type) {
-	case _XPC_TYPE_BOOL:
-	case _XPC_TYPE_INT64:
-	case _XPC_TYPE_UINT64:
-	case _XPC_TYPE_DATE:
-	case _XPC_TYPE_ENDPOINT:
+	if (xo->xo_xpc_type == XPC_TYPE_BOOL || xo->xo_xpc_type == XPC_TYPE_INT64 ||
+		xo->xo_xpc_type == XPC_TYPE_UINT64 || xo->xo_xpc_type == XPC_TYPE_DATE ||
+		xo->xo_xpc_type == XPC_TYPE_ENDPOINT) {
 		return ((size_t)xo->xo_u.port);
-
-	case _XPC_TYPE_STRING:
-		return (xpc_data_hash(
-		    (const uint8_t *)xpc_string_get_string_ptr(obj),
-		    xpc_string_get_length(obj)));
-
-	case _XPC_TYPE_DATA:
-		return (xpc_data_hash(
-		    xpc_data_get_bytes_ptr(obj),
-		    xpc_data_get_length(obj)));
-
-	case _XPC_TYPE_DICTIONARY:
-		xpc_dictionary_apply(obj, ^(const char *k, xpc_object_t v) {
+	} else if (xo->xo_xpc_type == XPC_TYPE_STRING) {
+		return (xpc_data_hash((const uint8_t *)xpc_string_get_string_ptr(obj), xpc_string_get_length(obj)));
+	} else if (xo->xo_xpc_type == XPC_TYPE_DATA) {
+		return (xpc_data_hash(xpc_data_get_bytes_ptr(obj), xpc_data_get_length(obj)));
+	} else if (xo->xo_xpc_type == XPC_TYPE_DICTIONARY) {
+		xpc_dictionary_apply(obj, ^bool(const char *k, xpc_object_t v) {
 			hash ^= xpc_data_hash((const uint8_t *)k, strlen(k));
 			hash ^= xpc_hash(v);
-			return ((bool)true);
+			return true;
 		});
 		return (hash);
-
-	case _XPC_TYPE_ARRAY:
-		xpc_array_apply(obj, ^(size_t idx, xpc_object_t v) {
+	} else if (xo->xo_xpc_type == XPC_TYPE_ARRAY) {
+		xpc_array_apply(obj, ^bool(size_t idx, xpc_object_t v) {
 			hash ^= xpc_hash(v);
-			return ((bool)true);
+			return true;
 		});
 		return (hash);
 	}
-    
+
     printf("end of unimplmented xpc_hash()\n");
     return 1; // _sjc_ nothing here, returned this now
 }
@@ -535,5 +520,5 @@ _xpc_get_type_name(xpc_object_t obj)
 	struct xpc_object *xo;
 
 	xo = obj;
-	return (xpc_typestr[xo->xo_xpc_type]);	
+	return xo->xo_xpc_type->description;
 }


### PR DESCRIPTION
Previously, we used an int field with confusingly similarly named enum values. I have not yet tested this, but I believe it should work.